### PR TITLE
2.0.2 Compatibility with PHPCS 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^5.4.0 || ^7.0",
-        "squizlabs/php_codesniffer": "^3.0",
+        "squizlabs/php_codesniffer": "^3.3",
         "phpmd/phpmd": "^2.0"
     },
     "require-dev": {

--- a/src/MediactCommon/Sniffs/Php7/ReturnTypeSniff.php
+++ b/src/MediactCommon/Sniffs/Php7/ReturnTypeSniff.php
@@ -162,7 +162,6 @@ class ReturnTypeSniff implements Sniff
     /**
      * @param File   $file
      * @param string $functionStart
-     * @param string $functionBodyStart
      *
      * @return string
      */

--- a/src/MediactCommon/Sniffs/Php7/ReturnTypeSniff.php
+++ b/src/MediactCommon/Sniffs/Php7/ReturnTypeSniff.php
@@ -44,14 +44,13 @@ class ReturnTypeSniff implements Sniff
             return;
         }
 
-        $functionStart     = $stackPtr;
-        $functionBodyStart = $this->findFunctionBodyStartIndex($file, $functionStart);
-        $commentEnd        = $this->findCommentEndIndex($file, $stackPtr);
-        $commentStart      = $this->findCommentStartIndex($file, $commentEnd);
+        $functionStart = $stackPtr;
+        $commentEnd    = $this->findCommentEndIndex($file, $stackPtr);
+        $commentStart  = $this->findCommentStartIndex($file, $commentEnd);
 
-        if ($commentStart && $functionBodyStart) {
+        if ($commentStart) {
             $suggestedReturnTypes = $this->findSuggestedReturnTypes($file, $commentStart);
-            $returnType           = $this->findActualReturnType($file, $functionStart, $functionBodyStart);
+            $returnType           = $this->findActualReturnType($file, $functionStart);
 
             $this->validateMultipleReturnTypes($file, $functionStart, $returnType, $suggestedReturnTypes);
             $this->validateReturnTypeNotEmpty($file, $functionStart, $returnType, $suggestedReturnTypes);
@@ -169,51 +168,9 @@ class ReturnTypeSniff implements Sniff
      */
     protected function findActualReturnType(
         File $file,
-        $functionStart,
-        $functionBodyStart
+        $functionStart
     ) {
-        $returnTypeIndex = $file->findNext(
-            T_RETURN_TYPE,
-            $functionStart,
-            $functionBodyStart
-        );
-
-        if (!$returnTypeIndex) {
-            // Sometimes the return tag has been parsed wrong by PHPCS
-            $returnTypeIndex = $this->findFunctionArrayReturnIndex(
-                $file,
-                $functionStart,
-                $functionBodyStart
-            );
-        }
-
-        return $returnTypeIndex
-            ? $file->getTokens()[$returnTypeIndex]['content']
-            : '';
-    }
-
-    /**
-     * @param File $file
-     * @param int  $functionStart
-     * @param int  $functionBodyStart
-     *
-     * @return int|bool
-     */
-    protected function findFunctionArrayReturnIndex(
-        File $file,
-        $functionStart,
-        $functionBodyStart
-    ) {
-        $closingIndex = $file->findNext(
-            T_CLOSE_PARENTHESIS,
-            $functionStart,
-            $functionBodyStart
-        );
-
-        return $file->findNext(
-            [T_ARRAY_HINT],
-            $closingIndex,
-            $functionBodyStart
-        );
+        $properties = $file->getMethodProperties($functionStart);
+        return $properties['return_type'];
     }
 }

--- a/src/MediactCommon/Sniffs/Php7/ReturnTypeSniff.php
+++ b/src/MediactCommon/Sniffs/Php7/ReturnTypeSniff.php
@@ -48,7 +48,7 @@ class ReturnTypeSniff implements Sniff
         $commentEnd    = $this->findCommentEndIndex($file, $stackPtr);
         $commentStart  = $this->findCommentStartIndex($file, $commentEnd);
 
-        if ($commentStart) {
+        if (is_int($commentStart) && is_int($commentEnd)) {
             $suggestedReturnTypes = $this->findSuggestedReturnTypes($file, $commentStart);
             $returnType           = $this->findActualReturnType($file, $functionStart);
 

--- a/src/MediactCommon/ruleset.xml
+++ b/src/MediactCommon/ruleset.xml
@@ -38,6 +38,7 @@
         <exclude name="Generic.Commenting.DocComment.ContentAfterOpen"/>
         <exclude name="Generic.Commenting.DocComment.ContentBeforeClose"/>
         <exclude name="Generic.Commenting.DocComment.MissingShort"/>
+        <exclude name="Generic.Commenting.DocComment.SpacingBeforeTags"/>
     </rule>
     <rule ref="Squiz.Commenting.FunctionComment">
         <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>


### PR DESCRIPTION
## Get the return type using File:getMethodProperties

The way that was used to get the return type is no longer working with
PHPCS 3.3. File:getMethodProperties gives the return type in a much
easier way.

## Exclude Generic.Commenting.DocComment.SpacingBeforeTags

The sniff marks single line property docs as invalid because there is no
white line. Single line property docs are recommended in the MediaCT
standard because they take up less space.
