### PR TITLE
2.0.3 Compatibility fixes for PHPCS 3.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^5.4.0 || ^7.0",
-        "squizlabs/php_codesniffer": "^3.3",
+        "squizlabs/php_codesniffer": "~3.3.0",
         "phpmd/phpmd": "^2.0"
     },
     "require-dev": {

--- a/src/MediactCommon/Sniffs/Php7/ReturnTypeSniff.php
+++ b/src/MediactCommon/Sniffs/Php7/ReturnTypeSniff.php
@@ -170,6 +170,6 @@ class ReturnTypeSniff implements Sniff
         $functionStart
     ) {
         $properties = $file->getMethodProperties($functionStart);
-        return $properties['return_type'];
+        return ltrim($properties['return_type'], '?');
     }
 }

--- a/src/MediactCommon/ruleset.xml
+++ b/src/MediactCommon/ruleset.xml
@@ -20,6 +20,8 @@
         <exclude name="Squiz.Arrays.ArrayDeclaration.NoCommaAfterLast"/>
         <exclude name="Squiz.Arrays.ArrayDeclaration.CloseBraceNotAligned"/>
         <exclude name="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.NoComma"/>
+        <exclude name="Squiz.Arrays.ArrayDeclaration.DoubleArrowNotAligned"/>
     </rule>
 
     <!-- Code analysis -->
@@ -39,6 +41,7 @@
         <exclude name="Generic.Commenting.DocComment.ContentBeforeClose"/>
         <exclude name="Generic.Commenting.DocComment.MissingShort"/>
         <exclude name="Generic.Commenting.DocComment.SpacingBeforeTags"/>
+        <exclude name="Generic.Commenting.DocComment.ParamNotFirst" />
     </rule>
     <rule ref="Squiz.Commenting.FunctionComment">
         <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>

--- a/src/MediactCommon/ruleset.xml
+++ b/src/MediactCommon/ruleset.xml
@@ -42,6 +42,7 @@
         <exclude name="Generic.Commenting.DocComment.MissingShort"/>
         <exclude name="Generic.Commenting.DocComment.SpacingBeforeTags"/>
         <exclude name="Generic.Commenting.DocComment.ParamNotFirst" />
+        <exclude name="Generic.Commenting.DocComment.TagValueIndent" />
     </rule>
     <rule ref="Squiz.Commenting.FunctionComment">
         <exclude name="Squiz.Commenting.FunctionComment.MissingParamComment"/>


### PR DESCRIPTION
New sniff from PHPCS have been disabled. PHPCS is now locked at 3.3.x to prevent the coding standard to change. The return type sniff had a bug when the return type was nullable.