### PR TITLE
2.0.4 Allow variable list on one line for multiline closures

### DIFF
--- a/src/MediactCommon/ruleset.xml
+++ b/src/MediactCommon/ruleset.xml
@@ -9,7 +9,9 @@
     <description>MediaCT its extension to PSR2.</description>
 
     <!-- Base rules on PSR2 -->
-    <rule ref="PSR2"/>
+    <rule ref="PSR2">
+        <exclude name="Squiz.Functions.MultiLineFunctionDeclaration.UseOneParamPerLine" />
+    </rule>
 
     <!-- Arrays -->
     <rule ref="Generic.Arrays.DisallowLongArraySyntax"/>


### PR DESCRIPTION
https://www.php-fig.org/psr/psr-2/#6-closures explicitly shows that the
following is allowed:

```
$longArgs_shortVars = function (
    $longArgument,
    $longerArgument,
    $muchLongerArgument
) use ($var1) {
    // body
};
```