### PR TITLE
Exclude PHPMD undefined variable check

### DIFF
--- a/src/MediaCT/phpmd.xml
+++ b/src/MediaCT/phpmd.xml
@@ -13,6 +13,7 @@
     <rule ref="rulesets/cleancode.xml">
         <exclude name="ElseExpression"/>
         <exclude name="StaticAccess"/>
+        <exclude name="UndefinedVariable"/>
     </rule>
     <rule ref="rulesets/codesize.xml"/>
     <rule ref="rulesets/design.xml"/>


### PR DESCRIPTION
The undefined variable check of PHPMD is currently broken, giving false positives.