### PR TITLE
Require newer version of PHPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^5.4.0 || ^7.0",
-        "squizlabs/php_codesniffer": "~3.3.0",
+        "squizlabs/php_codesniffer": "~3.5.0",
         "phpmd/phpmd": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
PHPCS has been fixed on specific version in the past to prevent unwanted coding standard changes. This older version however did not have a complete implementation of PSR12.