### PR TITLE
Ignore short and long class names

### DIFF
--- a/src/MediaCT/phpmd.xml
+++ b/src/MediaCT/phpmd.xml
@@ -28,6 +28,8 @@
     <rule ref="rulesets/naming.xml">
         <exclude name="ShortVariable"/>
         <exclude name="LongVariable"/>
+        <exclude name="ShortClassName"/>
+        <exclude name="LongClassName"/>
     </rule>
     <rule ref="rulesets/naming.xml/LongVariable">
         <properties>


### PR DESCRIPTION
These tests have been added in a new version of PHPMD and are not wanted.