### PR TITLE
Updated the module to also be compatible with latest testing suite mo…

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,4 +1,3 @@
 PHP_VERSION=7.4
-CLOUDSDK_PYTHON=/usr/bin/python
 GCLOUD_LOCAL="~/.config/gcloud"
 GIT_CONFIG_LOCAL="~/.gitconfig"

--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,4 @@
+PHP_VERSION=7.4
+CLOUDSDK_PYTHON=/usr/bin/python
+GCLOUD_LOCAL="~/.config/gcloud"
+GIT_CONFIG_LOCAL="~/.gitconfig"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 3.1.0 - 2021-03-10
+### Removed
+- PHP 5.x support.
+- Phpunit is required by mediact testing suite and is not a requirement for this module.
+
+### Fixed
+- PhpStorm 2020 has changed there config folder to a different path.
+
+### Changed
+- Refactored code to fix testing suite issues.
+
+### Added
+- [Dev Docker](https://github.com/mediact/docker-compose-development-manager)
+- Compatibility with latest testing suite module.

--- a/composer.json
+++ b/composer.json
@@ -10,13 +10,12 @@
         }
     ],
     "require": {
-        "php": "^5.4.0 || ^7.0",
+        "php": "^7.0",
         "squizlabs/php_codesniffer": "~3.5.0",
         "phpmd/phpmd": "^2.0"
     },
     "require-dev": {
-        "mediact/testing-suite": "@stable",
-        "phpunit/phpunit": "@stable"
+        "mediact/testing-suite": "@stable"
     },
     "autoload": {
         "psr-4": {
@@ -28,18 +27,21 @@
             "vendor/squizlabs/php_codesniffer/autoload.php"
         ]
     },
-    "extra": {
-        "grumphp": {
-            "config-default-path": "vendor/mediact/testing-suite/config/default/grumphp.yml"
-        }
-    },
     "archive": {
         "exclude": [
             "/.gitignore",
             "/phpunit.xml",
             "/phpmd.xml",
             "/phpstan.neon",
-            "/phpcs.xml"
+            "/phpcs.xml",
+            "/docker-compose.yml",
+            "/.env.dev",
+            "/grumphp.yml",
+            "/pdepend.xml",
+            "/tests"
         ]
+    },
+    "config": {
+        "sort-packages": true
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+# vim: ai:ts=2:sw=2:et
+version: "3.4"
+networks: {}
+volumes: {}
+
+x-custom:
+  version: 1.0.0
+  type: magento-2-module
+  environment: &env-vars
+    # Environment settings
+    - "HOME=${CHOME}"
+    - COMPOSER_MEMORY_LIMIT
+    - XDEBUG_CONFIG
+    - SSH_AUTH_SOCK
+
+services:
+  console:
+    image: "eu.gcr.io/mct-deployments/magento-2-console:${PHP_VERSION}"
+    user: "${UID}:${GID}"
+    network_mode: bridge
+    environment: *env-vars
+    working_dir: "${PWD}"
+    volumes:
+      - "${HOME}:${CHOME}"
+      - "${PWD}:${PWD}"
+      - "${GCLOUD_LOCAL}:/config/mygcloud"
+      - "${GIT_CONFIG_LOCAL}:/etc/gitconfig:ro"
+      - "${SSH_AUTH_SOCK}:${SSH_AUTH_SOCK}"
+      - /etc/group:/etc/group:ro
+      - /etc/passwd:/etc/passwd:ro
+      - /etc/shadow:/etc/shadow:ro

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,0 +1,2 @@
+imports:
+  - resource: 'vendor/mediact/testing-suite/config/default/grumphp.yml'

--- a/pdepend.xml
+++ b/pdepend.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<symfony:container xmlns:symfony="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://pdepend.org/schema/dic/pdepend"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <config>
+        <cache>
+            <driver>memory</driver>
+        </cache>
+    </config>
+</symfony:container>

--- a/src/FunctionTrait.php
+++ b/src/FunctionTrait.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
  */
+
 namespace Mediact\CodingStandard;
 
 use PHP_CodeSniffer\Files\File;

--- a/src/MediactCommon/Sniffs/NamingConventions/ValidVariableNameSniff.php
+++ b/src/MediactCommon/Sniffs/NamingConventions/ValidVariableNameSniff.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
@@ -45,7 +46,8 @@ class ValidVariableNameSniff implements Sniff
         $tokens  = $phpcsFile->getTokens();
         $varName = ltrim($tokens[$stackPtr]['content'], '$');
 
-        if (!in_array($varName, $this->allowedNames)
+        if (
+            !in_array($varName, $this->allowedNames)
             && preg_match('/^_/', $varName)
         ) {
             $phpcsFile->addWarning(

--- a/src/MediactCommon/Sniffs/Php7/ReturnTypeSniff.php
+++ b/src/MediactCommon/Sniffs/Php7/ReturnTypeSniff.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
  */
+
 namespace Mediact\CodingStandard\MediactCommon\Sniffs\Php7;
 
 use Mediact\CodingStandard\FunctionTrait;
@@ -72,7 +74,8 @@ class ReturnTypeSniff implements Sniff
         $returnType,
         array $suggestedReturnTypes
     ) {
-        if (empty($returnType)
+        if (
+            empty($returnType)
             && count($suggestedReturnTypes) > 1
         ) {
             $file->addWarning(
@@ -100,7 +103,8 @@ class ReturnTypeSniff implements Sniff
         array $suggestedReturnTypes
     ) {
         $filteredReturnTypes = array_filter($suggestedReturnTypes);
-        if (empty($returnType)
+        if (
+            empty($returnType)
             && count($suggestedReturnTypes) == 1
             && count($filteredReturnTypes) == 1
         ) {
@@ -130,7 +134,8 @@ class ReturnTypeSniff implements Sniff
         array $suggestedReturnTypes
     ) {
         $filteredReturnTypes = array_filter($suggestedReturnTypes);
-        if (!empty($returnType)
+        if (
+            !empty($returnType)
             && count($filteredReturnTypes)
             && !in_array($returnType, $filteredReturnTypes)
         ) {

--- a/src/MediactPhpUnit/Sniffs/Coverage/CoversTagSniff.php
+++ b/src/MediactPhpUnit/Sniffs/Coverage/CoversTagSniff.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
  */
+
 namespace Mediact\CodingStandard\MediactPhpUnit\Sniffs\Coverage;
 
 use Mediact\CodingStandard\FunctionTrait;
@@ -51,7 +53,8 @@ class CoversTagSniff implements Sniff
 
         $commentEnd   = $this->findCommentEndIndex($file, $stackPtr);
         $commentStart = $this->findCommentStartIndex($file, $commentEnd);
-        if ($commentStart
+        if (
+            $commentStart
             && $commentEnd
             && !$this->hasCoversNothingTag($file, $commentStart)
         ) {

--- a/src/PhpDocCommentTrait.php
+++ b/src/PhpDocCommentTrait.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
  */
+
 namespace Mediact\CodingStandard;
 
 use PHP_CodeSniffer\Files\File;
@@ -22,7 +24,8 @@ trait PhpDocCommentTrait
     {
         $searchTypes   = array_merge(Tokens::$methodPrefixes, [T_WHITESPACE]);
         $previousToken = $file->findPrevious($searchTypes, $elementIndex - 1, null, true);
-        if ($previousToken
+        if (
+            $previousToken
             && $file->getTokens()[$previousToken]['code'] == T_DOC_COMMENT_CLOSE_TAG
         ) {
             return $previousToken;

--- a/src/PhpVersionTrait.php
+++ b/src/PhpVersionTrait.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
  */
+
 namespace Mediact\CodingStandard;
 
 use PHP_CodeSniffer\Config;

--- a/src/TypeHintsTrait.php
+++ b/src/TypeHintsTrait.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright MediaCT. All rights reserved.
  * https://www.mediact.nl
  */
+
 namespace Mediact\CodingStandard;
 
 use PHP_CodeSniffer\Files\File;


### PR DESCRIPTION
…dule & dropped support php 5.x.

- PHP 5.x support.
- Phpunit is required by mediact testing suite and is not a requirement for this module.

- PhpStorm 2020 has changed there config folder to a different path.

- Refactored code to fix testing suite issues.

- [Dev Docker](https://github.com/mediact/docker-compose-development-manager)
- Compatibility with latest testing suite module.