### PR TITLE
Do not warn on missing phpdocs

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,6 +7,10 @@
     <description>PHPCS</description>
     <rule ref="./src/MediaCT">
         <exclude name="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing" />
+        <exclude name="Generic.Commenting.DocComment.MissingShort"/>
+        <exclude name="PEAR.Commenting.ClassComment.Missing"/>
+        <exclude name="PEAR.Commenting.FileComment.Missing"/>
+        <exclude name="PEAR.Commenting.FunctionComment.Missing"/>
         <exclude name="MediactCommon.Php7.ReturnType" />
     </rule>
 </ruleset>


### PR DESCRIPTION
I mean, it's 2021. We have type hints, typed properties, return type declarations and everything. Nobody needs docblocks.

This closes #17 